### PR TITLE
Support bytes data

### DIFF
--- a/get_image_size.py
+++ b/get_image_size.py
@@ -160,8 +160,11 @@ def get_image_size_from_reader(input: IO[bytes]) -> ImInfo:
     """
 
     data = input.read(30)
-    meta = fstat(input.fileno())
-    size = meta.st_size
+    try:
+        meta = fstat(input.fileno())
+        size = meta.st_size
+    except:
+        size = len(data)
 
     if size >= 10 and (data.startswith(b'GIF87a') or data.startswith(b'GIF89a')):
         # GIFs


### PR DESCRIPTION
Very useful in case we want to fetch only a few hundreds of bytes of an image from the internet and check image size/type, in case of writting adblock application, 1x1 gif images are usually for tracking purpose, and 720x200, 800x240... are usually for ads banner, so fetching a few hundreds of bytes and reject the rest of the data would be ideal.

But I do think my commits need some improments, currently it's using try except without Exception Name which is bad.

In this case we wan to do something like this:

```
import urllib3
import get_image_size

p = urllib3.PoolManager()
r = p.urlopen('GET', 'image_link', preload_content=False)
data = r.read(30)
info = get_image_size.get_image_size(data)
#Check image width, height
if info.width == 720 and info.height == 200:
    r.release_conn()
    #close connection, only 30 bytes downloaded
else:
   #process normally, download full Content-Length value
```